### PR TITLE
Fix #79: $not(x) is now translated as $nor[x] instead of $not(x), because apparently...

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/crud/mongo/Translator.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/mongo/Translator.java
@@ -135,7 +135,7 @@ public class Translator {
         NARY_LOGICAL_OPERATOR_MAP.put(NaryLogicalOperator._or, "$or");
 
         UNARY_LOGICAL_OPERATOR_MAP = new HashMap<>();
-        UNARY_LOGICAL_OPERATOR_MAP.put(UnaryLogicalOperator._not, "$nor");
+        UNARY_LOGICAL_OPERATOR_MAP.put(UnaryLogicalOperator._not, "$nor"); // Note: _not maps to $nor, not $not. $not applies to operator expression
 
         NARY_RELATIONAL_OPERATOR_MAP = new HashMap<>();
         NARY_RELATIONAL_OPERATOR_MAP.put(NaryRelationalOperator._in, "$in");
@@ -681,7 +681,7 @@ public class Translator {
     private DBObject translateUnaryLogicalExpression(FieldTreeNode context, UnaryLogicalExpression expr) {
         List<DBObject> l=new ArrayList<>(1);
         l.add(translate(context,expr.getQuery()));
-        return new BasicDBObject("$nor", l);
+        return new BasicDBObject(UNARY_LOGICAL_OPERATOR_MAP.get(expr.getOp()), l);
     }
 
     private DBObject translateNaryLogicalExpression(FieldTreeNode context, NaryLogicalExpression expr) {

--- a/crud/src/main/java/com/redhat/lightblue/crud/mongo/Translator.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/mongo/Translator.java
@@ -135,7 +135,7 @@ public class Translator {
         NARY_LOGICAL_OPERATOR_MAP.put(NaryLogicalOperator._or, "$or");
 
         UNARY_LOGICAL_OPERATOR_MAP = new HashMap<>();
-        UNARY_LOGICAL_OPERATOR_MAP.put(UnaryLogicalOperator._not, "$not");
+        UNARY_LOGICAL_OPERATOR_MAP.put(UnaryLogicalOperator._not, "$nor");
 
         NARY_RELATIONAL_OPERATOR_MAP = new HashMap<>();
         NARY_RELATIONAL_OPERATOR_MAP.put(NaryRelationalOperator._in, "$in");
@@ -679,7 +679,9 @@ public class Translator {
     }
 
     private DBObject translateUnaryLogicalExpression(FieldTreeNode context, UnaryLogicalExpression expr) {
-        return new BasicDBObject(UNARY_LOGICAL_OPERATOR_MAP.get(expr.getOp()), translate(context, expr.getQuery()));
+        List<DBObject> l=new ArrayList<>(1);
+        l.add(translate(context,expr.getQuery()));
+        return new BasicDBObject("$nor", l);
     }
 
     private DBObject translateNaryLogicalExpression(FieldTreeNode context, NaryLogicalExpression expr) {

--- a/crud/src/test/java/com/redhat/lightblue/crud/mongo/MongoCRUDControllerTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/crud/mongo/MongoCRUDControllerTest.java
@@ -686,6 +686,23 @@ public class MongoCRUDControllerTest extends AbstractMongoCrudTest {
     }
 
     @Test
+    public void elemMatchTest_Not() throws Exception {
+        EntityMetadata md = getMd("./testMetadata5.json");
+        TestCRUDOperationContext ctx = new TestCRUDOperationContext(Operation.INSERT);
+        ctx.add(md);
+        JsonDoc doc = new JsonDoc(loadJsonNode("./testdata5.json"));
+        Projection projection = projection("{'field':'_id'}");
+        ctx.addDocument(doc);
+        CRUDInsertionResponse response = controller.insert(ctx, projection);
+
+        ctx = new TestCRUDOperationContext(Operation.FIND);
+        ctx.add(md);
+        controller.find(ctx,query("{'array':'field7','elemMatch':{'$not':{'field':'elemf3','op':'$eq','rvalue':0}}}"),
+                        projection("{'field':'*','recursive':1}"),null,null,null);
+        Assert.assertEquals(1,ctx.getDocuments().size());
+     }
+
+   @Test
     public void entityIndexCreationTest() throws Exception {
         EntityMetadata e = new EntityMetadata("testEntity");
         e.setVersion(new Version("1.0.0", null, "some text blah blah"));


### PR DESCRIPTION
...  $not applies to operators, not expressions.