### PR TITLE
Rest issues13incorrect error code

### DIFF
--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -31,6 +31,12 @@
     <name>lightblue-mongo: ${project.groupId}|${project.artifactId}</name>
     <dependencies>
         <dependency>
+            <groupId>com.binarytweed</groupId>
+            <artifactId>quarantining-test-runner</artifactId>
+            <version>0.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-common</artifactId>
             <version>${project.version}</version>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>com.binarytweed</groupId>
             <artifactId>quarantining-test-runner</artifactId>
-            <version>0.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/mongo/MongoMetadataFailureTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/mongo/MongoMetadataFailureTest.java
@@ -1,0 +1,94 @@
+/*
+ Copyright 2013 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.metadata.mongo;
+
+import com.binarytweed.test.Quarantine;
+import com.binarytweed.test.QuarantiningRunner;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoCredential;
+import com.redhat.lightblue.OperationStatus;
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.common.mongo.MongoDataStore;
+import com.redhat.lightblue.crud.*;
+import com.redhat.lightblue.metadata.*;
+import com.redhat.lightblue.metadata.constraints.EnumConstraint;
+import com.redhat.lightblue.metadata.parser.Extensions;
+import com.redhat.lightblue.metadata.parser.JSONMetadataParser;
+import com.redhat.lightblue.metadata.types.DefaultTypes;
+import com.redhat.lightblue.metadata.types.IntegerType;
+import com.redhat.lightblue.metadata.types.StringType;
+import com.redhat.lightblue.mongo.test.EmbeddedMongo;
+import com.redhat.lightblue.query.Projection;
+import com.redhat.lightblue.query.QueryExpression;
+import com.redhat.lightblue.query.Sort;
+import com.redhat.lightblue.query.UpdateExpression;
+import com.redhat.lightblue.util.Error;
+import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.Path;
+import com.redhat.lightblue.util.test.AbstractJsonNodeTest;
+import org.bson.BSONObject;
+import org.json.JSONException;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+@RunWith(QuarantiningRunner.class)
+//Classloader isolation due EmbeddedMongo is a singleton instance
+@Quarantine({"com.redhat.lightblue.mongo.test.EmbeddedMongo"})
+public class MongoMetadataFailureTest {
+    
+    @Test
+    // Ignored due https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/114, resume this test build after it have been solved and we update our dependency to de.flapdoodle
+    @Ignore
+    public void mongoAuthFailureTest() throws Exception {
+        EmbeddedMongo.PORT = 2888;
+        EmbeddedMongo.MONGO_CREDENTIALS.add(MongoCredential.createMongoCRCredential("usera", EmbeddedMongo.DATABASE_NAME, "passworda".toCharArray()));
+        EmbeddedMongo mongo = EmbeddedMongo.getInstance();
+        MongoMetadata md;
+        Factory factory = new Factory();
+        factory.addCRUDController("mongo", new MongoMetadataTest.TestCRUDController());
+        Extensions<BSONObject> x = new Extensions<>();
+        x.addDefaultExtensions();
+        x.registerDataStoreParser("mongo", new MongoDataStoreParser<BSONObject>());
+        md = new MongoMetadata(mongo.getDB(), x, new DefaultTypes(), factory);
+        BasicDBObject index = new BasicDBObject("name", 1);
+        index.put("version.value", 1);
+        mongo.getDB().getCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION).ensureIndex(index, "name", true);
+
+        boolean passed=false;
+        try {
+            EntityMetadata g = md.getEntityMetadata("testEntity", null);
+        }catch (Error e){
+            passed=true;
+            Assert.assertEquals(MetadataConstants.ERR_AUTH_FAILED, e.getErrorCode());
+        }
+        Assert.assertTrue("Lightblue/mongodb didn't throw Error and that was expected to happen.",passed);
+    }
+}

--- a/metadata/src/test/java/com/redhat/lightblue/metadata/mongo/MongoMetadataTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/metadata/mongo/MongoMetadataTest.java
@@ -18,6 +18,9 @@
  */
 package com.redhat.lightblue.metadata.mongo;
 
+import java.lang.reflect.*;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.ArrayList;
@@ -81,7 +84,7 @@ public class MongoMetadataTest {
         mongo.reset();
     }
 
-    public class TestCRUDController implements CRUDController {
+    public static class TestCRUDController implements CRUDController {
 
         @Override
         public CRUDInsertionResponse insert(CRUDOperationContext ctx,

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,12 @@
                 <version>1.10.8</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.binarytweed</groupId>
+                <artifactId>quarantining-test-runner</artifactId>
+                <version>0.0.1</version>
+                <scope>test</scope>
+            </dependency>
          </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/test-application/src/main/java/com/redhat/lightblue/mongo/FrontEnd.java
+++ b/test-application/src/main/java/com/redhat/lightblue/mongo/FrontEnd.java
@@ -17,7 +17,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package com.redhat.lightblue.mongo;
-
+/*
 import java.io.FileReader;
 
 import com.mongodb.MongoClient;
@@ -58,9 +58,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;/*
  import com.redhat.lightblue.metadata.parser.JSONMetadataParser;
  import java.io.IOException;
 
- /**
+ /
  * Simple test front-end for metadata and mediator that works with one DB
- **/
+ */
 
 
 public class FrontEnd {


### PR DESCRIPTION
To solve the problem with authentication with the remote/local database described in https://github.com/lightblue-platform/lightblue-rest/issues/13 , create this PR which it depends on https://github.com/lightblue-platform/lightblue-core/pull/339 (a change on the core repository). Spend some time making the test for this change but found a blocker that  de.flapdoodle.embed.mongo doesn't allow authentication, so I created an issue (  https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/114 ) and left the draft for the test (which doesn't impact the other tests) to be resumed as soon as the dependency fix that problem and we update to the necessary version to have that feature.