### PR TITLE
Fixes #89 - Mongo test controller

### DIFF
--- a/add-copyright-to-java.sh
+++ b/add-copyright-to-java.sh
@@ -2,7 +2,7 @@
 
 FILES=`find . -name "*.java"`
 FILES=`grep -r --files-without-match "Copyright [0-9]* Red Hat" $FILES`
-COPYRIGHT="/*\n Copyright 2013 Red Hat, Inc. and/or its affiliates.\n\n This file is part of lightblue.\n\n This program is free software: you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n the Free Software Foundation, either version 3 of the License, or\n (at your option) any later version.\n\n This program is distributed in the hope that it will be useful,\n but WITHOUT ANY WARRANTY; without even the implied warranty of\n MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n GNU General Public License for more details.\n\n You should have received a copy of the GNU General Public License\n along with this program.  If not, see <http://www.gnu.org/licenses/>.\n */"
+COPYRIGHT="/*\n Copyright 2015 Red Hat, Inc. and/or its affiliates.\n\n This file is part of lightblue.\n\n This program is free software: you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n the Free Software Foundation, either version 3 of the License, or\n (at your option) any later version.\n\n This program is distributed in the hope that it will be useful,\n but WITHOUT ANY WARRANTY; without even the implied warranty of\n MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n GNU General Public License for more details.\n\n You should have received a copy of the GNU General Public License\n along with this program.  If not, see <http://www.gnu.org/licenses/>.\n */"
 
 # add copyright to ALL java files
 sed -u -i "s#^package#$COPYRIGHT\npackage#" $FILES

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.redhat.lightblue</groupId>
+             <artifactId>lightblue-core-test</artifactId>
+             <version>1.3.0-SNAPSHOT</version>
+             <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/test/src/main/java/com/redhat/lightblue/mongo/test/AbstractMongoCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/mongo/test/AbstractMongoCRUDTestController.java
@@ -1,3 +1,21 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.redhat.lightblue.mongo.test;
 
 import static com.redhat.lightblue.util.JsonUtils.json;

--- a/test/src/main/java/com/redhat/lightblue/mongo/test/AbstractMongoCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/mongo/test/AbstractMongoCRUDTestController.java
@@ -1,0 +1,44 @@
+package com.redhat.lightblue.mongo.test;
+
+import static com.redhat.lightblue.util.JsonUtils.json;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.mongo.test.MongoServerExternalResource.InMemoryMongoServer;
+import com.redhat.lightblue.test.AbstractCRUDTestController;
+
+@InMemoryMongoServer
+public abstract class AbstractMongoCRUDTestController extends AbstractCRUDTestController {
+
+    @ClassRule
+    public static MongoServerExternalResource mongoServer = new MongoServerExternalResource();
+
+    @BeforeClass
+    public static void prepareMongoDatasources() {
+        System.setProperty("mongo.host", "localhost");
+        System.setProperty("mongo.port", String.valueOf(mongoServer.getPort()));
+        System.setProperty("mongo.database", "lightblue");
+    }
+
+    public AbstractMongoCRUDTestController() throws Exception {
+        super(true);
+    }
+
+    @Override
+    protected JsonNode getDatasourcesJson() {
+        try {
+            if (getDatasourcesResourceName() == null) {
+                return json(loadResource("/mongo-datasources.json", true));
+            } else {
+                return json(loadResource(getDatasourcesResourceName(), false));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load resource '" + getDatasourcesResourceName() + "'", e);
+        }
+    }
+
+}

--- a/test/src/main/resources/mongo-datasources.json
+++ b/test/src/main/resources/mongo-datasources.json
@@ -1,0 +1,14 @@
+{
+    "mongo" : {
+        "type" : "com.redhat.lightblue.mongo.config.MongoConfiguration",
+        "metadataBackendParser" : "com.redhat.lightblue.metadata.mongo.MongoBackendParser",
+        "ssl" : false,
+        "database" : "${mongo.database}",
+        "servers" : [
+            {
+                "host" : "${mongo.host}",
+                "port" : "${mongo.port}"
+            }
+        ]
+   }
+}

--- a/test/src/test/java/com/redhat/lightblue/mongo/test/MongoServerExternalResourceTest.java
+++ b/test/src/test/java/com/redhat/lightblue/mongo/test/MongoServerExternalResourceTest.java
@@ -1,3 +1,21 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.redhat.lightblue.mongo.test;
 
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
Adds an implementation of AbstractCRUDTestController that has Mongo support built in, as that is the only supported metadata backend at this time.