### PR TITLE
fixes https://github.com/lightblue-platform/lightblue-audit-hook/issues/43

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/crud/mongo/MongoCRUDController.java
+++ b/crud/src/main/java/com/redhat/lightblue/crud/mongo/MongoCRUDController.java
@@ -161,7 +161,6 @@ public class MongoCRUDController implements CRUDController, MetadataListener {
                     try {
                         saver.saveDoc(ctx, operation.equals(OP_INSERT) ? DocSaver.Op.insert : DocSaver.Op.save,
                                 upsert, collection, md, dbObject, inputDoc);
-                        ctx.getHookManager().queueHooks(ctx);
                     } catch (Exception e) {
                         LOGGER.error("saveOrInsert failed: {}", e);
                         inputDoc.addError(analyzeException(e, operation, MongoCrudConstants.ERR_SAVE_ERROR, true));
@@ -178,6 +177,7 @@ public class MongoCRUDController implements CRUDController, MetadataListener {
                         ret++;
                     }
                 }
+                ctx.getHookManager().queueHooks(ctx);
             }
         } catch (Error e) {
             // rethrow lightblue error


### PR DESCRIPTION
Iterating over queueHooks for each document caused duplicate audits to be created

Fixes https://github.com/lightblue-platform/lightblue-audit-hook/issues/43