### PR TITLE
add javadoc to MongoServerExternalResource

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/mongo/test/MongoServerExternalResource.java
+++ b/test/src/main/java/com/redhat/lightblue/mongo/test/MongoServerExternalResource.java
@@ -55,6 +55,8 @@ import de.flapdoodle.embed.process.runtime.Network;
  *   level. This annotation allows properties of the Mongo instance to be configured, but is required even
  *   if only using the default values.
  * </p>
+ * <p>On occasion for debugging purposes, it is useful to connect to the running mongo instance. This can be achieved by
+ * placing a breakpoint in the unit test and then running <code>mongo --host localhost --port 27777</code> from your console.<p>
  *
  * @author dcrissman
  */


### PR DESCRIPTION
Adding documentation to explain how to connect to the running mongo instance directly if needed. I have found this to be useful.