### PR TITLE
remove the absolute need for InMemoryMongoServer annotation

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/mongo/test/MongoServerExternalResource.java
+++ b/test/src/main/java/com/redhat/lightblue/mongo/test/MongoServerExternalResource.java
@@ -63,6 +63,7 @@ import de.flapdoodle.embed.process.runtime.Network;
 public class MongoServerExternalResource extends ExternalResource {
 
     public static final int DEFAULT_PORT = 27777;
+    public static final Version DEFAULT_VERSION = Version.V2_6_1;
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.METHOD, ElementType.TYPE})
@@ -102,10 +103,6 @@ public class MongoServerExternalResource extends ExternalResource {
             immsAnnotation = description.getTestClass().getAnnotation(InMemoryMongoServer.class);
         }
 
-        if (immsAnnotation == null) {
-            throw new IllegalStateException("@InMemoryMongoServer must be set on suite or test level.");
-        }
-
         return super.apply(base, description);
     }
 
@@ -113,8 +110,8 @@ public class MongoServerExternalResource extends ExternalResource {
     protected void before() throws IOException {
         MongodStarter runtime = MongodStarter.getDefaultInstance();
         IMongodConfig config = new MongodConfigBuilder().
-                version(immsAnnotation.version()).
-                net(new Net(immsAnnotation.port(), Network.localhostIsIPv6())).
+                version(getMongoVersion()).
+                net(new Net(getPort(), Network.localhostIsIPv6())).
                 build();
         mongodExe = runtime.prepare(config);
 
@@ -156,7 +153,7 @@ public class MongoServerExternalResource extends ExternalResource {
      */
     public MongoClient getConnection() throws UnknownHostException {
         if (client == null) {
-            client = new MongoClient("localhost", immsAnnotation.port());
+            client = new MongoClient("localhost", getPort());
         }
         return client;
     }
@@ -165,14 +162,14 @@ public class MongoServerExternalResource extends ExternalResource {
      * @return the port the mongo instance is running on.
      */
     public int getPort() {
-        return immsAnnotation.port();
+        return (immsAnnotation == null) ? DEFAULT_PORT : immsAnnotation.port();
     }
 
     /**
      * @return the mongo version being run.
      */
     public Version getMongoVersion() {
-        return immsAnnotation.version();
+        return (immsAnnotation == null) ? DEFAULT_VERSION : immsAnnotation.version();
     }
 
 }

--- a/test/src/test/java/com/redhat/lightblue/mongo/test/MongoServerExternalResourceTest.java
+++ b/test/src/test/java/com/redhat/lightblue/mongo/test/MongoServerExternalResourceTest.java
@@ -19,35 +19,18 @@
 package com.redhat.lightblue.mongo.test;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
 
 import java.net.UnknownHostException;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 import com.mongodb.MongoClient;
-import com.redhat.lightblue.mongo.test.MongoServerExternalResource.InMemoryMongoServer;
 
-@InMemoryMongoServer
 public class MongoServerExternalResourceTest {
 
     @ClassRule
     public static final MongoServerExternalResource mongoServer = new MongoServerExternalResource();
-
-    @Test(expected = IllegalStateException.class)
-    public void testApply_WithoutAnnotation_onTestLevel() {
-        new MongoServerExternalResource().apply(mock(Statement.class), mock(Description.class));
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testApply_WithoutAnnotation_onClassLevel() {
-        new MongoServerExternalResource().apply(
-                mock(Statement.class),
-                Description.createSuiteDescription(Object.class));
-    }
 
     @Test
     public void testGetConnection() throws UnknownHostException {


### PR DESCRIPTION
If no overrides are specified, then the annotation is just botherson noise.