### PR TITLE
Adding thread pool key "mongodb" to AbstractMongoCommand

### DIFF
--- a/hystrix/src/main/java/com/redhat/lightblue/mongo/hystrix/AbstractMongoCommand.java
+++ b/hystrix/src/main/java/com/redhat/lightblue/mongo/hystrix/AbstractMongoCommand.java
@@ -49,7 +49,8 @@ public abstract class AbstractMongoCommand<T> extends HystrixCommand<T> {
      */
     public AbstractMongoCommand(String commandKey, DBCollection collection) {
         super(HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUPKEY)).
-                andCommandKey(HystrixCommandKey.Factory.asKey(GROUPKEY + ":" + commandKey)));
+                andCommandKey(HystrixCommandKey.Factory.asKey(GROUPKEY + ":" + commandKey)).
+                andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(GROUPKEY)));
         this.collection = collection;
     }
 


### PR DESCRIPTION
A likely fix to https://github.com/lightblue-platform/lightblue-mongo/issues/125.