### PR TITLE
Adding readPreference mongo driver option to MongoConfiguration

### DIFF
--- a/config/src/main/java/com/redhat/lightblue/mongo/config/MongoConfiguration.java
+++ b/config/src/main/java/com/redhat/lightblue/mongo/config/MongoConfiguration.java
@@ -28,6 +28,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
+
 import java.security.cert.X509Certificate;
 
 import org.slf4j.Logger;
@@ -40,10 +41,12 @@ import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.redhat.lightblue.config.DataSourceConfiguration;
 import com.redhat.lightblue.metadata.mongo.MongoDataStoreParser;
 import com.redhat.lightblue.metadata.parser.DataStoreParser;
+
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
@@ -74,6 +77,7 @@ public class MongoConfiguration implements DataSourceConfiguration {
     private boolean ssl = Boolean.FALSE;
     private boolean noCertValidation = Boolean.FALSE;
     private Class metadataDataStoreParser = MongoDataStoreParser.class;
+    private ReadPreference readPreference = null;
 
     public void addServerAddress(String hostname, int port) throws UnknownHostException {
         this.servers.add(new ServerAddress(hostname, port));
@@ -225,6 +229,9 @@ public class MongoConfiguration implements DataSourceConfiguration {
         if (connectionsPerHost != null) {
             builder.connectionsPerHost(connectionsPerHost);
         }
+
+        if (this.readPreference != null)
+            builder.readPreference(readPreference);
 
         if (ssl) {
             // taken from MongoClientURI, written this way so we don't have to
@@ -429,6 +436,21 @@ public class MongoConfiguration implements DataSourceConfiguration {
                     }
                 }
             }
+
+            JsonNode jsonNodeOptions = node.get("driverOptions");
+            if (jsonNodeOptions != null) {
+                JsonNode readPreferenceOption = jsonNodeOptions.get("readPreference");
+                if (readPreferenceOption != null)
+                    this.readPreference = ReadPreference.valueOf(readPreferenceOption.asText());
+            }
         }
+    }
+
+    public ReadPreference getReadPreference() {
+        return readPreference;
+    }
+
+    public void setReadPreference(ReadPreference readPreference) {
+        this.readPreference = readPreference;
     }
 }

--- a/config/src/test/java/com/redhat/lightblue/mongo/config/MongoConfigurationParseTest.java
+++ b/config/src/test/java/com/redhat/lightblue/mongo/config/MongoConfigurationParseTest.java
@@ -1,0 +1,29 @@
+package com.redhat.lightblue.mongo.config;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.mongodb.ReadPreference;
+import com.redhat.lightblue.util.JsonUtils;
+
+public class MongoConfigurationParseTest {
+
+    @Test
+    public void testReadPreference() throws IOException {
+
+        JsonNode node = JsonUtils.json(Thread.currentThread().getContextClassLoader().getResourceAsStream("datasources.json"));
+
+        MongoConfiguration metadataConfig = new MongoConfiguration();
+        metadataConfig.initializeFromJson(node.get("metadata"));
+
+        MongoConfiguration dataConfig = new MongoConfiguration();
+        dataConfig.initializeFromJson(node.get("mongodata"));
+
+        Assert.assertEquals(ReadPreference.nearest(), metadataConfig.getMongoClientOptions().getReadPreference());
+        Assert.assertEquals(ReadPreference.secondary(), dataConfig.getMongoClientOptions().getReadPreference());
+    }
+
+}

--- a/config/src/test/resources/datasources.json
+++ b/config/src/test/resources/datasources.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "documentation": [
+            "MongoDB makes a distinction between servers (a list) and ",
+            "server (a single address), even if servers contains a",
+            "single address. So, if servers field exists in this file,",
+            "then it assumes it is talking to a replica set, and will",
+            "want access to all the nodes. If instead server field ",
+            "exists, it only talks to that server.",
+            "WARNING: noCertValidation: this turns off all SSL certificate ",
+            "validations. It should be set to true only for development."
+        ],
+        "type": "com.redhat.lightblue.mongo.config.MongoConfiguration",
+        "metadataDataStoreParser": "com.redhat.lightblue.metadata.mongo.MongoDataStoreParser",
+        "ssl": true,
+        "database": "metadata",
+        "credentials": {
+            "mechanism": "MONGODB_CR_MECHANISM",
+            "userName": "lightblue",
+            "password": "password",
+            "source": "admin"
+        },
+        "server": {
+            "host": "lightbluemongo4.dev.int.phx1.redhat.com",
+            "port": "27017"
+        },
+        "driverOptions": {
+            "readPreference": "nearest"
+        }
+    },
+    "mongodata": {
+        "type": "com.redhat.lightblue.mongo.config.MongoConfiguration",
+        "metadataDataStoreParser": "com.redhat.lightblue.metadata.mongo.MongoDataStoreParser",
+        "ssl": true,
+        "database": "data",
+        "credentials": {
+            "mechanism": "MONGODB_CR_MECHANISM",
+            "userName": "lightblue",
+            "password": "password",
+            "source": "admin"
+        },
+        "server": {
+            "host": "lightbluemongo4.dev.int.phx1.redhat.com",
+            "port": "27017"
+        },
+        "driverOptions": {
+            "readPreference": "secondary"
+        }
+    }
+}


### PR DESCRIPTION
This setting is needed to be able to talk to non primary mongo nodes.

A better solution would be to use [MongoClientURI](http://api.mongodb.org/java/2.10.0/com/mongodb/MongoClientURI.html), as it would allow to specify any driver option without changing lightblue-mongo-config. However, I decided it's too deep of a change right now.