### PR TITLE
use the same datasource as the system properties

### DIFF
--- a/test/src/main/java/com/redhat/lightblue/mongo/test/AbstractMongoCRUDTestController.java
+++ b/test/src/main/java/com/redhat/lightblue/mongo/test/AbstractMongoCRUDTestController.java
@@ -65,6 +65,11 @@ public abstract class AbstractMongoCRUDTestController extends AbstractCRUDTestCo
     }
 
     @Override
+    protected String getDatasource() {
+        return System.getProperty("mongo.datasource");
+    }
+
+    @Override
     protected JsonNode getLightblueMetadataJson() throws Exception {
         return json(loadResource("/mongo-lightblue-metadata.json", AbstractMongoCRUDTestController.class), true);
     }


### PR DESCRIPTION
Fixes an issue where the mongo datasource could be different between the lightblue-metadata.json and the test metadata.