### PR TITLE
fixes #294 - remove unneeded and noisy logs and just let there be a debug level log

### DIFF
--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/Translator.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/Translator.java
@@ -302,7 +302,7 @@ public class Translator {
                 trc = ((DBObject) trc).get(segment);
             }
             if (trc == null && seg + 1 < n) {
-                LOGGER.warn(Error.get(MongoCrudConstants.ERR_TRANSLATION_ERROR, p.toString()).toString());
+                //At least one element in the Path is optional and does not exist in the document. Just return null.
                 LOGGER.debug("Error retrieving path {} with {} segments from {}", p, p.numSegments(), start);
                 return null;
             }


### PR DESCRIPTION
Error.get(...) will log the message at an ERROR level, then that message is duplicated at a WARN level. Both are not needed, and I argue neither is needed as explained in #294 this seems to be a legitimate use case.