### PR TITLE
Initialize locking and sequences collections only once per jvm

### DIFF
--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoLocking.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoLocking.java
@@ -20,8 +20,8 @@ package com.redhat.lightblue.mongo.crud;
 
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,7 @@ public class MongoLocking implements Locking {
     private long defaultTTL = 60l * 60l * 1000l;// 1 hr
 
     // a set of locking collections which were already initialized
-    private static Set<String> initializedCollections = new HashSet<>();
+    private static Set<String> initializedCollections = new CopyOnWriteArraySet<>();
 
     public MongoLocking(DBCollection coll) {
         this(coll, false);

--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoLocking.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoLocking.java
@@ -18,19 +18,21 @@
  */
 package com.redhat.lightblue.mongo.crud;
 
-import java.util.Date;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.mongodb.WriteConcern;
-import com.mongodb.ReadPreference;
-import com.mongodb.WriteResult;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.DuplicateKeyException;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
 import com.redhat.lightblue.extensions.synch.InvalidLockException;
 import com.redhat.lightblue.extensions.synch.Locking;
 
@@ -49,8 +51,24 @@ public class MongoLocking implements Locking {
     private DBCollection coll;
     private long defaultTTL = 60l * 60l * 1000l;// 1 hr
 
+    // a set of locking collections which were already initialized
+    private static Set<String> initializedCollections = new HashSet<>();
+
     public MongoLocking(DBCollection coll) {
-        init(coll);
+        this(coll, false);
+    }
+
+    /**
+     *
+     * @param coll
+     * @param forceCollectionInit set to true in unit tests, where collections are wiped out between the tests
+     */
+    public MongoLocking(DBCollection coll, boolean forceCollectionInit) {
+        if (forceCollectionInit || !initializedCollections.contains(coll.getFullName())) {
+            init(coll);
+            initializedCollections.add(coll.getFullName());
+            LOGGER.info("Initialized locking collection {}", coll.getFullName());
+        }
     }
 
     public void init(DBCollection coll) {

--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoSequenceGenerator.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoSequenceGenerator.java
@@ -57,6 +57,9 @@ public class MongoSequenceGenerator {
         coll.createIndex(keys, options);
     }
 
+    // true when sequance collection is initialized and indexes created
+    private static boolean initialized = false;
+
     /**
      * Atomically increments and returns the sequence value. If this is the
      * first use of the sequence, the sequence is created
@@ -84,8 +87,14 @@ public class MongoSequenceGenerator {
             if (inc == 0) {
                 inc = 1;
             }
-            // Here, we also make sure we have the indexes setup properly
-            initIndex();
+
+            if (!initialized) {
+                // Here, we also make sure we have the indexes setup properly
+                initIndex();
+                initialized = true;
+                LOGGER.info("Initialized sequances collection");
+            }
+
             BasicDBObject u = new BasicDBObject().
                     append(NAME, name).
                     append(INIT, init).

--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoSequenceGenerator.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoSequenceGenerator.java
@@ -18,8 +18,8 @@
  */
 package com.redhat.lightblue.mongo.crud;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
-import com.mongodb.WriteConcern;
 import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
 
 /**
  * Sequence generation using a MongoDB collection.
@@ -49,7 +49,7 @@ public class MongoSequenceGenerator {
     private final DBCollection coll;
 
     // a set of sequances collections which were already initialized
-    private static Set<String> initializedCollections = new HashSet<>();
+    private static Set<String> initializedCollections = new CopyOnWriteArraySet<>();
 
     public MongoSequenceGenerator(DBCollection coll) {
         this.coll = coll;

--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoLockingTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoLockingTest.java
@@ -29,7 +29,7 @@ public class MongoLockingTest extends AbstractMongoCrudTest {
     @Test
     public void acquireExclusionTest() throws Exception {
         // Make sure only one caller can lock
-        MongoLocking locking = new MongoLocking(coll);
+        MongoLocking locking = new MongoLocking(coll, true);
         Assert.assertTrue(locking.acquire("1", "rsc1", null));
         Assert.assertFalse(locking.acquire("2", "rsc1", null));
         Assert.assertTrue(locking.release("1", "rsc1"));
@@ -39,7 +39,7 @@ public class MongoLockingTest extends AbstractMongoCrudTest {
 
     @Test
     public void acquireLockCountingTest() throws Exception {
-        MongoLocking locking = new MongoLocking(coll);
+        MongoLocking locking = new MongoLocking(coll, true);
         Assert.assertTrue(locking.acquire("1", "rsc1", null));
         Assert.assertFalse(locking.acquire("2", "rsc1", null));
         Assert.assertEquals(1, locking.getLockCount("1", "rsc1"));
@@ -61,7 +61,7 @@ public class MongoLockingTest extends AbstractMongoCrudTest {
 
     @Test
     public void expireTest() throws Exception {
-        MongoLocking locking = new MongoLocking(coll);
+        MongoLocking locking = new MongoLocking(coll, true);
         Assert.assertTrue(locking.acquire("1", "rsc1", 100l));
         Thread.sleep(110);
         try {
@@ -75,7 +75,7 @@ public class MongoLockingTest extends AbstractMongoCrudTest {
 
     @Test
     public void pingTest() throws Exception {
-        MongoLocking locking = new MongoLocking(coll);
+        MongoLocking locking = new MongoLocking(coll, true);
         Assert.assertTrue(locking.acquire("1", "rsc1", 100l));
         locking.ping("1", "rsc1");
         Thread.sleep(50);


### PR DESCRIPTION
https://github.com/lightblue-platform/lightblue-mongo/issues/317