### PR TITLE
Partial index support

### DIFF
--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoCRUDController.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoCRUDController.java
@@ -826,8 +826,13 @@ public class MongoCRUDController implements CRUDController, MetadataListener, Ex
                 options.append("background", true);
                 // partial index
                 if (index.getProperties().containsKey(PARTIAL_FILTER_EXPRESSION_OPTION_NAME)) {
-                    DBObject filter = (DBObject) JSON.parse(index.getProperties().get(PARTIAL_FILTER_EXPRESSION_OPTION_NAME).toString());
-                    options.append(PARTIAL_FILTER_EXPRESSION_OPTION_NAME, filter);
+                    try {
+                        @SuppressWarnings("unchecked")
+                        DBObject filter = new BasicDBObject((Map<String,Object>)index.getProperties().get(PARTIAL_FILTER_EXPRESSION_OPTION_NAME));
+                        options.append(PARTIAL_FILTER_EXPRESSION_OPTION_NAME, filter);
+                    } catch (ClassCastException e) {
+                        throw new RuntimeException("Index property "+PARTIAL_FILTER_EXPRESSION_OPTION_NAME +" needs to be a mongo query in json format", e);
+                    }
                 }
                 LOGGER.debug("Creating index {} with options {}", newIndex, options);
                 LOGGER.warn("Creating index {} with fields={}, options={}", index.getName(), index.getFields(), options);

--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
@@ -423,7 +423,7 @@ public class MongoCRUDControllerTest extends AbstractMongoCrudTest {
         DBCollection entityCollection = db.getCollection("data");
         DBObject indexCreated = entityCollection.getIndexInfo().get(1);
         Assert.assertEquals("testPartialIndex", indexCreated.get("name"));
-        Assert.assertEquals("{ \"field3\" : { \"$gt\" : 5}}", indexCreated.get("partialFilterExpression").toString());
+        Assert.assertEquals("{ \"$and\" : [ { \"field3\" : { \"$gt\" : 5}} , { \"field3\" : { \"$lt\" : 100}}]}", indexCreated.get("partialFilterExpression").toString());
 
         TestCRUDOperationContext ctx = new TestCRUDOperationContext(CRUDOperation.INSERT);
         ctx.add(md);

--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
@@ -415,18 +415,7 @@ public class MongoCRUDControllerTest extends AbstractMongoCrudTest {
 
     @Test
     public void createPartialIndex_CI() throws Exception {
-        EntityMetadata md = getMd("./testMetadata.json");
-
-        Index index = new Index();
-        index.setName("testPartialIndex");
-        List<IndexSortKey> indexFields1 = new ArrayList<>();
-        indexFields1.add(new IndexSortKey(new Path("field1"), true));
-        index.setFields(indexFields1);
-        index.setUnique(true);
-        // only index documents where field3 > 5
-        index.getProperties().put("partialFilterExpression", "{ field3: { $gt: 5 } }");
-
-        md.getEntityInfo().getIndexes().add(index);
+        EntityMetadata md = getMd("./testMetadata_partialIndex.json");
 
         // save metadata
         controller.afterUpdateEntityInfo(null, md.getEntityInfo(), true);

--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -467,13 +468,31 @@ public class MongoCRUDControllerTest extends AbstractMongoCrudTest {
 
         dbI.append("foo", "bar2");
         Assert.assertTrue("Property foo should be ignored, indexes equal", MongoCRUDController.indexOptionsMatch(i, dbI));
+    }
 
-        DBObject filter1 = (DBObject) JSON.parse("{\"$and\": [{\"field3\": { \"$gt\": 5 }},{\"field3\": { \"$lt\": 100 }}]}");
-        DBObject filter2 = (DBObject) JSON.parse("{\"$and\": [{\"field3\": { \"$gt\": 5 }},{\"field3\": { \"$lt\": 101 }}]}");
+    @Test
+    public void indexOptionMatchTest_partialFilterExpression() {
+        EntityMetadata md = getMd("./testMetadata_partialIndex.json");
 
-        i.getProperties().put(MongoCRUDController.PARTIAL_FILTER_EXPRESSION_OPTION_NAME, filter1);
-        dbI.append(MongoCRUDController.PARTIAL_FILTER_EXPRESSION_OPTION_NAME, filter2);
-        Assert.assertFalse("Different partialFilterExpression means indexes are not equal", MongoCRUDController.indexOptionsMatch(i, dbI));
+        // save metadata
+        controller.afterUpdateEntityInfo(null, md.getEntityInfo(), true);
+
+        DBCollection entityCollection = db.getCollection("data");
+        DBObject indexFromDb = entityCollection.getIndexInfo().get(1);
+        Assert.assertEquals("testPartialIndex", indexFromDb.get("name"));
+
+        Map<String,Object> filter = (Map<String,Object>) JSON.parse("{\"$and\": [{\"field3\": { \"$gt\": 5 }},{\"field3\": { \"$lt\": 100 }}]}");
+
+        Index i = new Index();
+        i.setUnique(true);
+        i.getProperties().put(MongoCRUDController.PARTIAL_FILTER_EXPRESSION_OPTION_NAME, filter);
+
+        Assert.assertTrue("partialFilterExpression index option is the same, indexes should match", MongoCRUDController.indexOptionsMatch(i, indexFromDb));
+
+        Map<String,Object> filter2 = (Map<String,Object>) JSON.parse("{\"$and\": [{\"field3\": { \"$gt\": 5 }},{\"field3\": { \"$lt\": 101 }}]}");
+        i.getProperties().put(MongoCRUDController.PARTIAL_FILTER_EXPRESSION_OPTION_NAME, filter2);
+
+        Assert.assertFalse("partialFilterExpression index option is different, indexes should not match", MongoCRUDController.indexOptionsMatch(i, indexFromDb));
     }
 
     @Test

--- a/mongo/src/test/resources/testMetadata_partialIndex.json
+++ b/mongo/src/test/resources/testMetadata_partialIndex.json
@@ -15,7 +15,7 @@
 		         ],
 		         "name": "testPartialIndex",
 		         "unique": true,
-		         "partialFilterExpression": "{ \"field3\": { \"$gt\": 5 } }"
+		         "partialFilterExpression": { "field3": { "$gt": 5 } }
             }
         ]
     },

--- a/mongo/src/test/resources/testMetadata_partialIndex.json
+++ b/mongo/src/test/resources/testMetadata_partialIndex.json
@@ -15,7 +15,7 @@
 		         ],
 		         "name": "testPartialIndex",
 		         "unique": true,
-		         "partialFilterExpression": { "field3": { "$gt": 5 } }
+		         "partialFilterExpression": { "$and": [{"field3": { "$gt": 5 }},{"field3": { "$lt": 100 }}]}
             }
         ]
     },

--- a/mongo/src/test/resources/testMetadata_partialIndex.json
+++ b/mongo/src/test/resources/testMetadata_partialIndex.json
@@ -1,0 +1,88 @@
+{
+    "entityInfo": {
+        "name": "test",
+        "datastore": {
+            "backend":"mongo",
+            "collection": "data"
+        },
+        "indexes": [
+            {
+                "fields": [
+                    {
+		                "field": "field1",
+		                "dir": "$asc"
+		             }
+		         ],
+		         "name": "testPartialIndex",
+		         "unique": true,
+		         "partialFilterExpression": "{ \"field3\": { \"$gt\": 5 } }"
+            }
+        ]
+    },
+    "schema": {
+        "name": "test",
+        "version": {
+            "value": "1.0",
+            "changelog": "blahblah"
+        },
+        "status": {
+            "value": "active"
+        },
+        "access" : {
+             "insert" : ["anyone"],
+             "update" : ["anyone"],
+             "delete" : [ "anyone" ] ,
+             "find" : [ "anyone" ]
+        },
+        "fields": {
+            "objectType": {"type": "string"},
+            "_id": {"type": "string"},
+            "field1": {"type": "string"},
+            "field2": {"type": "string"},
+            "field3": {"type": "integer"},
+            "field4": {"type": "bigdecimal"},
+            "field5": {"type": "boolean"},
+            "field6": {
+                "type": "object",
+                "fields": {
+                    "nf1": {"type": "string"},
+                    "nf2": {"type": "string"},
+                    "nf3": {"type": "integer"},
+                    "nf4": {"type": "boolean"},
+                    "nf5": {
+                        "type": "array",
+                        "items": {"type": "integer"}
+                    },
+                    "nf6": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "nf7": {
+                        "type": "object",
+                        "fields": {
+                            "nnf1": {"type": "string"},
+                            "nnf2": {"type": "integer"}
+                        }
+                    }
+                }
+            },
+            "field7": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "fields": {
+                        "elemf1": {"type": "string"},
+                        "elemf2": {"type": "string"},
+                        "elemf3": {"type": "integer"}
+                    }
+                }
+            },
+            "ref": {
+                "type":"reference",
+                "entity":"test",
+                "versionValue":"1.0",
+                "query":{"field":"_id","op":"=","rvalue":1}
+            }
+        }
+    }
+}

--- a/mongo/src/test/resources/testdata_partial_index.json
+++ b/mongo/src/test/resources/testdata_partial_index.json
@@ -1,0 +1,82 @@
+[{
+  "objectType":"test",
+  "field1":"f1",
+  "field2":"f2",
+  "field3":1,
+  "field4":123.45,
+  "field5":true,
+  "field6":{
+      "nf1":"v1",
+      "nf2":"v2",
+      "nf3":2,
+      "nf4":false,
+      "nf5":[1,2,3,4,5],
+      "nf6":["one","two"],
+      "nf7": {
+  "nnf1":"value1",
+  "nnf2": 3
+      }
+  },
+  "field7": [
+  { "elemf1":"value0_1",
+    "elemf2":"value0_2",
+     "elemf3":0 },
+  { "elemf1":"value1_1",
+    "elemf2":"value1_2",
+    "elemf3":1 } ]
+ },
+ {
+  "objectType":"test",
+  "field1":"f1",
+  "field2":"f2",
+  "field3":6,
+  "field4":123.45,
+  "field5":true,
+  "field6":{
+      "nf1":"v1",
+      "nf2":"v2",
+      "nf3":2,
+      "nf4":false,
+      "nf5":[1,2,3,4,5],
+      "nf6":["one","two"],
+      "nf7": {
+  "nnf1":"value1",
+  "nnf2": 3
+      }
+  },
+  "field7": [
+  { "elemf1":"value0_1",
+    "elemf2":"value0_2",
+     "elemf3":0 },
+  { "elemf1":"value1_1",
+    "elemf2":"value1_2",
+    "elemf3":1 } ]
+ },
+ {
+  "objectType":"test",
+  "field1":"f1",
+  "field2":"f2",
+  "field3":10,
+  "field4":123.45,
+  "field5":true,
+  "field6":{
+      "nf1":"v1",
+      "nf2":"v2",
+      "nf3":2,
+      "nf4":false,
+      "nf5":[1,2,3,4,5],
+      "nf6":["one","two"],
+      "nf7": {
+  "nnf1":"value1",
+  "nnf2": 3
+      }
+  },
+  "field7": [
+  { "elemf1":"value0_1",
+    "elemf2":"value0_2",
+     "elemf3":0 },
+  { "elemf1":"value1_1",
+    "elemf2":"value1_2",
+    "elemf3":1 } ]
+ }
+ ]

--- a/test/src/main/java/com/redhat/lightblue/mongo/test/MongoServerExternalResource.java
+++ b/test/src/main/java/com/redhat/lightblue/mongo/test/MongoServerExternalResource.java
@@ -72,7 +72,7 @@ import de.flapdoodle.embed.process.runtime.Network;
 public class MongoServerExternalResource extends ExternalResource {
 
     public static final int DEFAULT_PORT = 27777;
-    public static final Version DEFAULT_VERSION = Version.V2_6_8;
+    public static final Version DEFAULT_VERSION = Version.V3_1_6;
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.METHOD, ElementType.TYPE})
@@ -87,7 +87,7 @@ public class MongoServerExternalResource extends ExternalResource {
         /**
          * Version of Mongo to use.
          */
-        Version version() default Version.V2_6_8;
+        Version version() default Version.V3_1_6;
     }
 
     private InMemoryMongoServer immsAnnotation = null;


### PR DESCRIPTION
https://github.com/lightblue-platform/lightblue-mongo/issues/311

* Using mongo 3.1.x for testing (upgrade required for partial indexing support). This means no more regression testing for 2.6.x.
* Is there any policy on backend specific option naming? Like mongo-partialFilterExpression prefix?

