### PR TITLE
Define partialFilterExpression as a string after all

### DIFF
--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
@@ -492,10 +492,17 @@ public class MongoCRUDControllerTest extends AbstractMongoCrudTest {
 
         Assert.assertTrue("partialFilterExpression index option is the same, indexes should match", MongoCRUDController.indexOptionsMatch(metadataIndex, indexFromDb));
 
-        // remove one element from the filter expression
-        ((ArrayList)((java.util.HashMap)metadataIndex.getProperties().get(MongoCRUDController.PARTIAL_FILTER_EXPRESSION_OPTION_NAME)).get("$and")).remove(1);
+        // change filter expression
+        metadataIndex.getProperties().put(MongoCRUDController.PARTIAL_FILTER_EXPRESSION_OPTION_NAME, "{\"field3\": { \"$gt\": 5 }}");
 
         Assert.assertFalse("partialFilterExpression index option is different, indexes should not match", MongoCRUDController.indexOptionsMatch(metadataIndex, indexFromDb));
+
+        // change filter expression to invalid
+        metadataIndex.getProperties().put(MongoCRUDController.PARTIAL_FILTER_EXPRESSION_OPTION_NAME, "{\"field3\": \"$gt\": 5 }}");
+        try {
+            MongoCRUDController.indexOptionsMatch(metadataIndex, indexFromDb);
+            Assert.fail("Invalid partialFilterExpression should result in an exception");
+        } catch (RuntimeException e) {}
     }
 
     @Test

--- a/mongo/src/test/resources/testMetadata_partialIndex.json
+++ b/mongo/src/test/resources/testMetadata_partialIndex.json
@@ -15,7 +15,7 @@
 		         ],
 		         "name": "testPartialIndex",
 		         "unique": true,
-		         "partialFilterExpression": { "$and": [{"field3": { "$gt": 5 }},{"field3": { "$lt": 100 }}]}
+		         "partialFilterExpression": "{ \"$and\": [{\"field3\": { \"$gt\": 5 }},{\"field3\": { \"$lt\": 100 }}]}"
             }
         ]
     },


### PR DESCRIPTION
to be able to define fields with a dot in it's name: https://github.com/lightblue-platform/lightblue-mongo/issues/329

This is not ideal (json defined as a value in json), but I'm in a hurry before today's release. 