### PR TITLE
Fix #359: merge adds references of elements from the old doc into the…

### DIFF
--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/BsonMerge.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/BsonMerge.java
@@ -23,11 +23,13 @@ import java.util.Map;
 import java.util.Iterator;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.ArrayList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.mongodb.DBObject;
+import com.mongodb.BasicDBObject;
 
 import com.redhat.lightblue.metadata.EntityMetadata;
 
@@ -323,6 +325,26 @@ public final class BsonMerge extends DocComparator<Object, Object, DBObject, Lis
         } else {
             parent = doc;
         }
-        parent.put(newFieldName.tail(0), removedField.getRemovedNode());
+        parent.put(newFieldName.tail(0), copy(removedField.getRemovedNode()));
+    }
+
+    private static Object copy(Object fld) {
+        Object ret;
+        if(fld instanceof List) {
+            ArrayList<Object> l=new ArrayList<>();
+            for(Object s:(List)fld) {
+                l.add(copy(s));
+            }
+            ret=l;
+        } else if (fld instanceof DBObject) {
+            DBObject r=new BasicDBObject();
+            for(String s:((DBObject)fld).keySet()) {
+                r.put(s,copy( ((DBObject)fld).get(s)));
+            }
+            ret=r;
+        } else {
+            ret=fld;
+        }
+        return ret;
     }
 }

--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoSafeUpdateProtocol.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/MongoSafeUpdateProtocol.java
@@ -272,13 +272,10 @@ public abstract class MongoSafeUpdateProtocol implements BatchUpdate {
             if(updatedDoc!=null) {
                 // if updatedDoc is null, doc is lost. Error remains
                 DBObject newDoc=reapplyChanges(index,updatedDoc);
-                // WARNING There is a potential for major screwup
-                // here, so be careful when you're changing this
-                // code. reapplyChanges implementation calls merge(),
-                // which adds a reference to @mongoHidden at the root
-                // level in the old document into the new
-                // document. This is NOT a copy, a reference. So, the
-                // setDocVer call below sets the version of BOTH docs
+                // Make sure reapplyChanges does not insert references
+                // of objects from the old document into the
+                // updatedDoc. That updates both copies of
+                // documents. Use deepCopy
                 if(newDoc!=null) {
                     DBObject replaceQuery=writeReplaceQuery(updatedDoc);
                     // Update the doc ver to our doc ver. This doc is here

--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoSafeUpdateProtocolTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoSafeUpdateProtocolTest.java
@@ -226,7 +226,7 @@ public class MongoSafeUpdateProtocolTest extends AbstractMongoCrudTest {
                     // Emulating merging behavior here. When we merge
                     // documents, we put references to missing items
                     // from the old document into the new
-                    // document. Once of these references is
+                    // document. One of these references is
                     // the @mongoHidden element at the root. This
                     // contains the document versions. So after
                     // merging, we have two copies of the same


### PR DESCRIPTION
… new doc, and one of these references is the version info, so any modifications to the version info after the merge modifies both docs