### PR TITLE
Add health details at individual database level

### DIFF
--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
@@ -2974,7 +2974,7 @@ public class MongoCRUDControllerTest extends AbstractMongoCrudTest {
         
         CRUDHealth healthCheck = unhealthyController.checkHealth();
         
-		Map<String, Object> validMongoMap = (Map<String, Object>) healthCheck.details().get("valid-mongo");
+        Map<String, Object> validMongoMap = (Map<String, Object>) healthCheck.details().get("valid-mongo");
         Map<String, Object> invalidMongoMap = (Map<String, Object>) healthCheck.details().get("invalid-mongo");
         
         Assert.assertTrue((boolean) validMongoMap.get("isHealthy"));


### PR DESCRIPTION
The earlier implementation has a bug which can result in /diagnostics endpoint reporting MongoCRUDController. isHealthy : "true" even if connection fails for one of the database because the looping swallows the older isHealthy value and uses the latest isHealthy value intead.

To avoid such instances (however unlikely they may be), this PR includes a isHealthy attribute at each database level along with a overall isHealthy status for /diagnostics call.
