### PR TITLE
CRUD controller includes documents which failed to update in results

### DIFF
--- a/mongo/src/main/java/com/redhat/lightblue/mongo/crud/IterateAndUpdate.java
+++ b/mongo/src/main/java/com/redhat/lightblue/mongo/crud/IterateAndUpdate.java
@@ -282,6 +282,7 @@ public class IterateAndUpdate implements DocUpdater {
                         }
                     } else {
                         numFailed++;
+                        resultDocs.add(doc);
                     }
                 } else {
                     LOGGER.debug("Document {} was not modified", docIndex);

--- a/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
+++ b/mongo/src/test/java/com/redhat/lightblue/mongo/crud/MongoCRUDControllerTest.java
@@ -1422,6 +1422,12 @@ public class MongoCRUDControllerTest extends AbstractMongoCrudTest {
                 projection("{'field':'*','recursive':1}"));
         Assert.assertEquals(0, upd.getNumUpdated());
         Assert.assertEquals(1, upd.getNumFailed());
+
+        Assert.assertEquals(1, getDataErrors(ctx).size());
+        Assert.assertEquals(1, getDataErrors(ctx).get(0).getErrors().size());
+        Error error = getDataErrors(ctx).get(0).getErrors().get(0);
+        Assert.assertEquals("crud:Required", error.getErrorCode());
+        Assert.assertEquals("field1", error.getMsg());
     }
 
     @Test


### PR DESCRIPTION
This is to address on of the problems identified in https://github.com/lightblue-platform/lightblue-core/issues/811

The constraints enforcement is a bit unclear to me.

For inserts and saves, constraints are enforced at the Mediator level. CRUD Controller allows insertion of a document with a null required field (there is even a test for that behavior: MongoCRUDControllerTest.insertTest_nullReqField).

For updates, this is enforced at the controller level, probably because we need a full document to check constraints, so it has to be read first. However, if constraints are not satisfied, crud controller indicates that only by setting the matchCount and modifiedCount fields accordingly. The status of the response is COMPLETE. I think it should be ERROR or PARTIAL and the failed documents should be included in the response, but I'm not sure I understand the intention behind all this.